### PR TITLE
Filesystem config

### DIFF
--- a/src/config/filesystems.php
+++ b/src/config/filesystems.php
@@ -36,23 +36,23 @@ return [
             'throw' => false,
         ],
 
+        'pdf-templates' => [
+            'driver' => 'local',
+            'root' => storage_path('app/pdf_templates'),
+            'throw' => false,
+        ],
+
+        'pdf-exports' => [
+            'driver' => 'local',
+            'root' => storage_path('app/pdf_exports'),
+            'throw' => false,
+        ],
+
         'public' => [
             'driver' => 'local',
             'root' => storage_path('app/public'),
             'url' => env('APP_URL').'/storage',
             'visibility' => 'public',
-            'throw' => false,
-        ],
-
-        's3' => [
-            'driver' => 's3',
-            'key' => env('AWS_ACCESS_KEY_ID'),
-            'secret' => env('AWS_SECRET_ACCESS_KEY'),
-            'region' => env('AWS_DEFAULT_REGION'),
-            'bucket' => env('AWS_BUCKET'),
-            'url' => env('AWS_URL'),
-            'endpoint' => env('AWS_ENDPOINT'),
-            'use_path_style_endpoint' => env('AWS_USE_PATH_STYLE_ENDPOINT', false),
             'throw' => false,
         ],
 

--- a/src/config/filesystems.php
+++ b/src/config/filesystems.php
@@ -48,6 +48,12 @@ return [
             'throw' => false,
         ],
 
+        'uploads' => [
+            'driver' => 'local',
+            'root' => storage_path('app/user_uploads'),
+            'throw' => false,
+        ],
+
         'public' => [
             'driver' => 'local',
             'root' => storage_path('app/public'),


### PR DESCRIPTION
Funguje to takto (podla [filesystem docs](https://laravel.com/docs/10.x/filesystem)):

Mame 3 custom disky, ktore "mountuju" zodpovedajuce adresare do aplikacie:
* `pdf-templates` mapovany na `storage/app/pdf_templates` pre pdf templaty dokumentov, ktore budeme generovat
* `pdf-exports` mapovany na `storage/app/pdf_exports` pre docasne ulozenie vygenerovanych dokumentov
* `uploads` mapovany na `storage/app/user_uploads` pre ukladanie attachmentov k cestam

Ked chcem pracovat s uloziskom, pouzijem facade `Storage` (podrobnejsie v `BusinessTripController.php` v #65):
```php
Storage::disk('disk-name')->...
```

Napriklad, ked chcem ulozit upload (podla [uploads docs](https://laravel.com/docs/10.x/filesystem#file-uploads)):
```php
Storage::disk('uploads')->putFile('', $request->file(...));
```
kde prvy parameter metody `putFile` nechame prazdny string.

Ten `Storage` ponuka aj ine metody, napriklad `get` na ziskavanie obsahu suboru, `download`, `exists`, `missing`, etc.