### PR TITLE
Differently colored icons

### DIFF
--- a/src/app/Enums/TripState.php
+++ b/src/app/Enums/TripState.php
@@ -90,6 +90,18 @@ enum TripState: int
         };
     }
 
+    public function iconColor(): string
+    {
+        return match ($this) {
+            TripState::NEW => '#ffb000',
+            TripState::CONFIRMED => '#00baff',
+            TripState::COMPLETED => '#00a000',
+            TripState::CLOSED => '#575757',
+            TripState::CANCELLATION_REQUEST => '#FF0000',
+            TripState::CANCELLED => '#d9390c',
+        };
+    }
+
     public function hasTravellerReturned(): bool
     {
         return match ($this) {

--- a/src/resources/views/components/state-icon.blade.php
+++ b/src/resources/views/components/state-icon.blade.php
@@ -3,5 +3,5 @@
 <span
     class="state-icon"
     title="{{ $state->inSlovak() }}">
-    <i class="fa-solid fa-{{ $state->icon() }}"></i>
+    <i class="fa-solid fa-{{ $state->icon() }}" style="color: {{ $state->iconColor() }};"></i>
 </span>


### PR DESCRIPTION
Každá ikona stavu cesty má teraz vlastnú farbu pre lepšiu odlíšiteľnosť. [Pôvodný issue](https://github.com/orgs/TIS2024-FMFI/projects/8/views/1?&pane=issue&itemId=91727520&issue=TIS2024-FMFI%7Cgastro%7C61).